### PR TITLE
feat: New action to create file on remote

### DIFF
--- a/actions/create_transfer_complete_file.yaml
+++ b/actions/create_transfer_complete_file.yaml
@@ -1,0 +1,22 @@
+name: create_transfer_complete_file
+description: Create a Done.txt with a date in a given directory.
+runner_type: "remote-shell-cmd"
+enabled: true
+entry_point: ""
+parameters:
+  cwd:
+    default: "/home/monbr970/stackstorm_target/"
+  cmd:
+    default: "echo `date` > Done.txt;"
+  username:
+    type: string 
+    default: "monbr970"
+  private_key: 
+    type: string
+    default: "/etc/ssh_keys/id_ed25519"
+  passphrase:
+    type: string
+    default: ""
+  hosts: 
+    type: string
+    default: "marvin.cgu.igp.uu.se"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,7 @@ services:
       # Action runner needs access to keys since action definitions (Jinja
       # templates) can reference secrets
       - stackstorm-keys:/etc/st2/keys:ro
+      - /home/monika/.ssh_stackstorm:/etc/ssh_keys:ro
   st2garbagecollector:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2garbagecollector:${ST2_VERSION:-latest}
     restart: on-failure


### PR DESCRIPTION
Run new action from st2client with:
`st2 run arteria.create_transfer_complete_file passphrase=<passphrase>`
